### PR TITLE
Added way to specify interfaces for IP's

### DIFF
--- a/src/dispatcher/mod.rs
+++ b/src/dispatcher/mod.rs
@@ -1,6 +1,6 @@
 mod weighted_rr;
 
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 
 use eyre::Result;
 
@@ -8,5 +8,5 @@ pub use weighted_rr::{WeightedAddress, WeightedRoundRobinDispatcher};
 
 #[async_trait::async_trait]
 pub trait Dispatch {
-    async fn dispatch(&self, remote_address: &SocketAddr) -> Result<IpAddr>;
+    async fn dispatch(&self, remote_address: &SocketAddr) -> Result<WeightedAddress>;
 }

--- a/src/list.rs
+++ b/src/list.rs
@@ -25,7 +25,7 @@ pub fn list() {
                 .into_iter()
                 .map(|addr| addr.ip())
                 .filter(|addr| !is_local_address(addr))
-                .filter(|addr| bind_socket(*addr).is_ok())
+                .filter(|addr| bind_socket(*addr, "".to_string()).is_ok())
                 .collect();
             addrs.sort_by_key(|addr| addr.is_ipv6());
             addrs

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ enum Command {
         /// Which port to listen to for connections
         #[structopt(default_value = "1080", long)]
         port: u16,
-        /// The network interface IP addresses to dispatch to, in the form of <address>[@priority]
+        /// The network interface IP addresses to dispatch to, in the form of <address>[@interface][@priority]
         #[structopt(required = true, parse(try_from_str = WeightedAddress::from_str))]
         addresses: Vec<WeightedAddress>,
     },

--- a/src/net.rs
+++ b/src/net.rs
@@ -4,7 +4,7 @@ use tracing::instrument;
 use tokio::net::TcpSocket;
 
 #[instrument]
-pub fn bind_socket(addr: IpAddr) -> std::io::Result<TcpSocket> {
+pub fn bind_socket(addr: IpAddr, interface_name: String) -> std::io::Result<TcpSocket> {
     let socket = match addr {
         IpAddr::V4(_) => TcpSocket::new_v4()?,
         IpAddr::V6(_) => TcpSocket::new_v6()?,
@@ -12,6 +12,9 @@ pub fn bind_socket(addr: IpAddr) -> std::io::Result<TcpSocket> {
 
     socket.set_reuseaddr(true)?;
     socket.bind((addr, 0).into())?;
+    if !interface_name.is_empty() {
+        socket.bind_device(Some(interface_name.as_bytes())).unwrap();
+    }
 
     Ok(socket)
 }


### PR DESCRIPTION
Fixes #26.
The new format for IP's is `<address>[@interface][@priority]`.
I'm not experienced enough of a Rustacean to make a new whole command, but this works excellently for me.
The trick is to use `socket.bind_device`.